### PR TITLE
GH033: fix static links

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,9 +19,9 @@ services:
       retries: 3
     environment:
       - PROVIDER=$PROVIDER
-      - MONGO_USERNAME=$MONGO_USERNAME
-      - MONGO_PASSWORD=$MONGO_PASSWORD
-      - MONGO_DB_HOST=$MONGO_DB_HOST
+      - MONGO_USERNAME=${MONGO_USERNAME:?}
+      - MONGO_PASSWORD=${MONGO_PASSWORD:?}
+      - MONGO_DB_HOST=mongodb:27017
       - ASSETS_URL=$ASSETS_URL
 
   cli:
@@ -35,12 +35,13 @@ services:
   mongodb:
     image: mongo:latest
     environment:
-      - MONGO_INITDB_ROOT_USERNAME=$MONGO_USERNAME
-      - MONGO_INITDB_ROOT_PASSWORD=$MONGO_PASSWORD
+      - MONGO_INITDB_ROOT_USERNAME=${MONGO_USERNAME:?}
+      - MONGO_INITDB_ROOT_PASSWORD=${MONGO_PASSWORD:?}
     ports:
       - 27017:27017
     volumes:
       - mongodb-data:/data/db
+      - mongodb-config:/data/configdb
 
   nginx-proxy:
     build: docker/nginx
@@ -67,3 +68,4 @@ services:
 
 volumes:
   mongodb-data:
+  mongodb-config:

--- a/docker/web/Dockerfile
+++ b/docker/web/Dockerfile
@@ -1,7 +1,10 @@
 # Dockerfile
 
 # pull the official docker image
-FROM python:3.7-slim
+FROM python:3.8-slim
+
+# install curl (for healthcheck)
+RUN apt-get update && apt-get -y install curl
 
 # set work directory
 WORKDIR /app

--- a/tests/tests_api/test_utils.py
+++ b/tests/tests_api/test_utils.py
@@ -4,8 +4,8 @@ from bio3dbeacons.api import utils
 class TestUtils:
     def test_get_model_asset_url_default(self):
         result = utils.get_model_asset_url("someEntryId")
-        assert result == "localhost/static/cif/someEntryId.cif"
+        assert result == "/static/cif/someEntryId.cif"
 
     def test_get_model_asset_url_pdb(self):
         result = utils.get_model_asset_url("someEntryId", "pdb")
-        assert result == "localhost/static/pdb/someEntryId.pdb"
+        assert result == "/static/pdb/someEntryId.pdb"


### PR DESCRIPTION
Fixes the documentation around accessing static mmCIF files

* README suggested accessing web pages via `localhost:8000`
* API is hosted on port 8000, however the nginx frontend is available on port 80
* nginx frontend is responsible for serving static files
* all docs now refer to using `localhost` rather than `localhost:8000` (for API docs and static files)

Addresses #33 