### PR TITLE
Support UniProt accessions with "submittedName"

### DIFF
--- a/bio3dbeacons/cli/ciftojson/ciftojson.py
+++ b/bio3dbeacons/cli/ciftojson/ciftojson.py
@@ -71,10 +71,16 @@ class Cif2Json:
             namespace = "{http://uniprot.org/uniprot}"
             # fetch accession related data
             ac_id = xml_root.find(f"./{namespace}entry/{namespace}name").text
-            description = xml_root.find(
-                f"./{namespace}entry/{namespace}protein/{namespace}recommendedName"
-                f"/{namespace}fullName"
-            ).text
+            try:
+                description = xml_root.find(
+                    f"./{namespace}entry/{namespace}protein/{namespace}recommendedName"
+                    f"/{namespace}fullName"
+                ).text
+            except:
+                description = xml_root.find(
+                    f"./{namespace}entry/{namespace}protein/{namespace}submittedName"
+                    f"/{namespace}fullName"
+                ).text
 
             # fetch gene related data
             gene = xml_root.find(


### PR DESCRIPTION
This modification is intended to make 3d-beacons-client support UniProt accessions with "submittedName" instead of "recommendedName". (e.g. [A0A6J0HQ00](https://rest.uniprot.org/uniprotkb/A0A6J0HQ00.xml))